### PR TITLE
Handle data URL screenshots in scanner reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "node --test --import tsx server/**/*.test.ts",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/server/services/scanner.test.ts
+++ b/server/services/scanner.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import fs from 'fs/promises';
+import PDFDocument from 'pdfkit';
+import { generateReport } from './scanner.ts';
+
+const BASE64_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/ivv0wAAAABJRU5ErkJggg==';
+
+function createResults(screenshot: string) {
+  return {
+    violations: [],
+    passes: [],
+    incomplete: [],
+    screenshot
+  };
+}
+
+async function runWithScreenshot(screenshot: string) {
+  let received: unknown;
+  const original = PDFDocument.prototype.image;
+  PDFDocument.prototype.image = function (src: any, ...rest: any[]) {
+    received = src;
+    return this as any;
+  };
+  try {
+    const reportPath = await generateReport('http://example.com', createResults(screenshot));
+    assert.ok(Buffer.isBuffer(received));
+    await fs.unlink(reportPath);
+  } finally {
+    PDFDocument.prototype.image = original;
+  }
+}
+
+test('generateReport handles screenshot without prefix', async () => {
+  await runWithScreenshot(BASE64_PNG);
+});
+
+test('generateReport handles screenshot with data URL prefix', async () => {
+  await runWithScreenshot(`data:image/png;base64,${BASE64_PNG}`);
+});

--- a/server/services/scanner.ts
+++ b/server/services/scanner.ts
@@ -836,7 +836,12 @@ export async function generateReport(url: string, results: ScanResult): Promise<
         doc.moveDown(0.5);
         
         // Add screenshot to PDF
-        const screenshotBuffer = Buffer.from(results.screenshot, 'base64');
+        let screenshotData = results.screenshot;
+        if (screenshotData.startsWith('data:image/')) {
+          const commaIndex = screenshotData.indexOf(',');
+          screenshotData = commaIndex !== -1 ? screenshotData.substring(commaIndex + 1) : screenshotData;
+        }
+        const screenshotBuffer = Buffer.from(screenshotData, 'base64');
         doc.image(screenshotBuffer, {
           fit: [400, 300],
           align: 'center'


### PR DESCRIPTION
## Summary
- Strip `data:image/` prefixes from screenshots before decoding in report generation
- Add `npm test` script and unit tests for screenshot handling

## Testing
- `npm test`
- `npm run check` *(fails: Property 'length' does not exist on type '{}', plus other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68baf86a5a54832d9653945481b91318